### PR TITLE
Fix toggleArrow icon dimension

### DIFF
--- a/src/size/icons.json
+++ b/src/size/icons.json
@@ -7,7 +7,7 @@
           "comment": "style guide value 8px"
         },
         "vertical": {
-          "width": { "value": 0.25 },
+          "height": { "value": 0.25 },
           "comment": "style guide value 4px"
         }
       },


### PR DESCRIPTION
# Alaska Airlines Pull Request

Vertical dimension was referred to as "width". Changed to "height" to match structure of chevronArrow token.

**Fixes:** # (issue, if applicable)

## Summary:

Vertical dimension was referred to as "width". Changed to "height" to match structure of chevronArrow token.

## Type of change:


- [ ] Revision of an existing capability

## Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
