### PR TITLE
fix: quote multi-word font families in font stacks

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,4 +1,4 @@
-# Migrating from `v4`
+# Migrating from v4
 
 This guide provides instructions for migrating from Auro Design Tokens `v4`.
 

--- a/src/themes/auro-classic/text.json
+++ b/src/themes/auro-classic/text.json
@@ -2,13 +2,13 @@
   "font": {
     "family": {
       "default": {
-        "value": "'{asset.font.circular.familyName.value}', Helvetica Neue, Arial, sans-serif",
+        "value": "{asset.font.circular.familyName.value}, Helvetica Neue, Arial, sans-serif",
         "type": "semantic",
         "public": true,
         "deprecated": true
       },
       "mono": {
-        "value": "Menlo, Monaco, Consolas, 'Courier New', monospace",
+        "value": "Menlo, Monaco, Consolas, Courier New, monospace",
         "type": "semantic",
         "public": true,
         "deprecated": true


### PR DESCRIPTION
# Alaska Airlines Pull Request

Refactors the `fontFamilyTransform` in `styleDictionary` to correctly handle both single and comma-separated font stacks, converting and normalizing quotes for family names containing spaces, and includes minor doc and comment cleanups.

## The Bug

A change to `fontFamilyTransform` in `v6.0.0` negatively impacted font stacks containing single quotes `'`, such as those used in Auro Classic.

After compilation, font stacks included in Auro Classic were rendered with a hanging `'`:

```
"AS Circular', Helvetica Neue, Arial, sans-serif";
```

Instead of the correct rendering for font families with spaces, wrapped in `"`:

```
"AS Circular", "Helvetica Neue", Arial, sans-serif;
```

This was partly due to Auro Classic wrapping font families in `'` within the JSON, while also being inconsistent in quoting families with multiple words—for example, not wrapping "Helvetica Neue" in quotes.

## Example transformations after fix

```
* - "AS Circular" → "AS Circular" (already properly formatted)
* - 'Good OT' → "Good OT" (single quotes converted to double)
* - Helvetica Neue → "Helvetica Neue" (unquoted value gets quoted)
* - 'Open Sans → "Open Sans" (handles malformed input with missing end quote)
* - 'Circular', Helvetica Neue, Arial → "Circular", "Helvetica Neue", Arial
 ```

## Testing

- `dist` folder generated for `v6.0.0` (`master`) and `v6.0.1` (this PR)
- Tested compiled files using a diff checker

### Diff Tests

#### Auro Classic

- CSSCustomProperties.css - https://www.diffchecker.com/op6QKBaE/

- JSObject--allTokens.js - https://www.diffchecker.com/yoSuM1K8/ (turn on “Real-time diff”)

- SassCustomProperties.scss - https://www.diffchecker.com/zz71ExhA/

- SCSSVariables.scss - https://www.diffchecker.com/DBpPSKsV/

#### v6 Themes

- CSSCustomProperties--alaska - https://www.diffchecker.com/7JCDZ7P6/

- CSSCustomProperties--alaskaclassic.css - https://www.diffchecker.com/Y08DSDQG/

- CSSCustomProperties--auro1.css - https://www.diffchecker.com/KyPuQ3Z0/

- CSSCustomProperties--hawaiian.css - https://www.diffchecker.com/Xxg0voF6/

- CSSCustomProperties--transparent.css - https://www.diffchecker.com/ETuUuaQH/

### Diff Results

- Observed that only the `font-family` values changed in Auro Classic
- Font families containing spaces were correctly wrapped in `"`
- No changes observed in `v6` themes such as Alaska, Alaska Classic, Auro 1, Auro 2, and Hawaiian (expected results)

## Final Results

Fixes font family quoting in Style Dictionary transform to correctly wrap names with spaces in double quotes and handle multi-font stacks

### Bug Fixes:
- Ensure font family names containing spaces are quoted with double quotes in CSS output

### Enhancements:
- Enhance `fontFamilyTransform` to process font stacks individually, convert single quotes to double quotes, and preserve generic font names

### Documentation:
- Update migration guide heading to remove backtick formatting from version reference

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team