### PR TITLE
fix(dist): ensure output filenames use camelCase

### DIFF
--- a/scripts/styleDictionary.mjs
+++ b/scripts/styleDictionary.mjs
@@ -12,11 +12,15 @@ const __dirname = dirname(__filename);
 
 /**
  * Converts a directory name to a format without hyphens
+ * For names with letters after hyphens (e.g., 'alaska-classic'), converts to camelCase ('alaskaClassic')
+ * For names with numbers after hyphens (e.g., 'auro-1'), removes the hyphen ('auro1')
  * @param {string} dirName - The directory name
- * @returns {string} The directory name without hyphens
+ * @returns {string} The processed directory name
  */
 const removeHyphens = (dirName) => {
-  return dirName.replace(/-/g, '');
+  return dirName.replace(/-([a-z])/g, (match, letter) => letter.toUpperCase())
+                // Remove hyphen before numbers
+               .replace(/-([0-9])/g, '$1');
 };
 
 // Legacy themes - uses individual config files

--- a/scripts/transformCSS.mjs
+++ b/scripts/transformCSS.mjs
@@ -59,6 +59,7 @@ async function transformCSSFiles() {
     for (const { dir, code } of THEME_DEFINITIONS) {
       const scope = getThemeAttribute(code);
       
+      // Get all CSS files in the directory, not relying on specific naming patterns
       const cssFiles = await findCSSFiles(PATHS.DIST, dir);
       if (cssFiles.length === 0) {
         console.log(`No CSS files found in ${PATHS.DIST}/${dir} directory`);


### PR DESCRIPTION
# Alaska Airlines Pull Request

During the build process, files that require camelCase—such as `alaskaClassic`—were being output with kebab-case filenames like `alaskaclassic`, which broke imports in consuming apps.

## Why was this missed during development?

macOS is case-insensitive by default, which means when importing camelCase:

```
@import '../../node_modules/@aurodesignsystem/design-tokens/dist/alaska-classic/SCSSVariables--alaskaClassic';
```

macOS will match it to kebab-case:

```
node_modules/@aurodesignsystem/design-tokens/dist/alaska-classic/SCSSVariables--alaskaclassic.scss
```

As a result, the local build did not fail, however when deployed to the CI/CD environment that uses Linux/Unix, it failed.

## Testing

- `npm run build`
- Observe themes are `camelCase` in the `dist` folder
- Themes with numbers (Auro 1, Auro 2) do not have hyphens

![Screenshot 2025-06-02 at 9 24 52 AM](https://github.com/user-attachments/assets/131ca5f8-5e72-4d87-8f4a-cc54cb20d026)

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure output filenames use camelCase formatting instead of flattened names to preserve proper theme imports

Bug Fixes:
- Update removeHyphens to convert hyphenated directory names to camelCase instead of simply stripping hyphens

Enhancements:
- Clarify CSS file discovery to include all CSS files regardless of naming patterns

## Summary by Sourcery

Ensure generated distribution files use camelCase names for theme imports and broaden CSS file detection in the build scripts.

Bug Fixes:
- Convert hyphenated directory names to camelCase and properly strip hyphens before numbers in the removeHyphens utility.

Enhancements:
- Modify the CSS transformation script to discover all CSS files in output directories regardless of naming patterns.