### PR TITLE
feat: export primitive base tokens in dist

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -56,6 +56,6 @@ Special-purpose transparent theme (v4.x):
 
 | File | Syntax | Type | Description |
 |------|--------|------|-------------|
-| CSSCustomProperties--bundled.css | CSS | Custom properties | Combined v6.x `semantic` CSS custom properties from all supported themes, scoped to a `data-aag-theme` attribute |
+| themes/CSSCustomProperties--bundled.css | CSS | Custom properties | Combined v6.x `semantic` CSS custom properties from all supported themes, scoped to a `data-aag-theme` attribute |
 
 **NOTE: The bundled file is not intended for general use.**

--- a/scripts/config-primitives-base.json
+++ b/scripts/config-primitives-base.json
@@ -1,0 +1,65 @@
+{
+  "source": [
+    "./src/primitives/base/**/*.json"
+  ],
+  "platforms": {
+    "SCSSVariables": {
+      "transformGroup": "scss",
+      "prefix": "ds",
+      "comment": "File type: SCSS; variable type: Sass; base primitives",
+      "buildPath": "./dist/primitives/base/",
+      "files": [
+        {
+          "destination": "SCSSVariables--primitivesBase.scss",
+          "format": "scss/variables",
+          "filter": {
+            "deprecated": false
+          }
+        },
+        {
+          "destination": "SCSSVariablesMapFlat--primitivesBase.scss",
+          "format": "custom/scss/map-flat",
+          "mapName": "auroPrimitiveBaseTokens",
+          "filter": {
+            "deprecated": false
+          }
+        }
+      ]
+    },
+    "JSONVariables": {
+      "transformGroup": "css",
+      "prefix": "ds",
+      "comment": "File type: JSON; variable type: CSS; base primitives",
+      "buildPath": "./dist/primitives/base/",
+      "files": [
+        {
+          "destination": "JSONVariablesNested--primitivesBase.json",
+          "format": "json/nested",
+          "filter": {
+            "deprecated": false
+          }
+        }
+      ]
+    },
+    "JSObject--allTokens": {
+      "transformGroup": "js",
+      "prefix": "ds",
+      "comment": "File type: JS; data type: JS; base primitives",
+      "buildPath": "./dist/primitives/base/",
+      "transforms": [
+        "attribute/cti",
+        "name/cti/kebab",
+        "color/css"
+      ],
+      "files": [
+        {
+          "destination": "JSObject--allTokens.js",
+          "format": "javascript/module",
+          "filter": {
+            "deprecated": false
+          }
+        }
+      ]
+    }
+  }
+}

--- a/scripts/config-themes.json
+++ b/scripts/config-themes.json
@@ -11,7 +11,7 @@
       "transformGroup": "css",
       "prefix": "ds",
       "comment": "File type: CSS; variable type: CSS; filter: public",
-      "buildPath": "./dist/{{themeDir}}/",
+      "buildPath": "./dist/themes/{{themeDir}}/",
       "files": [
         {
           "destination": "CSSCustomProperties--{{themeDirNoHyphens}}.css",
@@ -27,7 +27,7 @@
       "transformGroup": "scss",
       "prefix": "ds",
       "comment": "File type: SCSS; variable type: Sass; filter: public",
-      "buildPath": "./dist/{{themeDir}}/",
+      "buildPath": "./dist/themes/{{themeDir}}/",
       "files": [
         {
           "destination": "SCSSVariables--{{themeDirNoHyphens}}.scss",
@@ -52,7 +52,7 @@
       "transformGroup": "css",
       "prefix": "ds",
       "comment": "File type: JSON; variable type: CSS; filter: public",
-      "buildPath": "./dist/{{themeDir}}/",
+      "buildPath": "./dist/themes/{{themeDir}}/",
       "files": [
         {
           "destination": "JSONVariablesNested--{{themeDirNoHyphens}}.json",
@@ -68,7 +68,7 @@
       "transformGroup": "scss",
       "prefix": "{{themeCode}}",
       "comment": "File type: SCSS; variable type: Sass; filter: primitive",
-      "buildPath": "./dist/{{themeDir}}/",
+      "buildPath": "./dist/themes/{{themeDir}}/",
       "files": [
         {
           "destination": "primitives--{{themeDirNoHyphens}}.scss",
@@ -84,7 +84,7 @@
       "transformGroup": "js",
       "prefix": "ds",
       "comment": "File type: JS; data type: JS; filter: classic colors",
-      "buildPath": "./dist/{{themeDir}}/",
+      "buildPath": "./dist/themes/{{themeDir}}/",
       "transforms": [
         "attribute/cti",
         "name/cti/kebab",

--- a/scripts/legacy/config-auroClassic.json
+++ b/scripts/legacy/config-auroClassic.json
@@ -6,7 +6,7 @@
       "transformGroup": "scss",
       "prefix": "ds",
       "comment": "File type: SCSS; variable type: Sass; filter: public",
-      "buildPath": "./dist/auro-classic/",
+      "buildPath": "./dist/legacy/auro-classic/",
       "files": [
         {
           "destination": "SCSSVariables.scss",
@@ -29,7 +29,7 @@
       "transformGroup": "css",
       "prefix": "ds",
       "comment": "File type: JSON; variable type: CSS; filter: public",
-      "buildPath": "./dist/auro-classic/",
+      "buildPath": "./dist/legacy/auro-classic/",
       "files": [
         {
           "destination": "JSONVariablesFlat.json",
@@ -52,7 +52,7 @@
       "prefix": "ds",
       "comment": "File type: SCSS; variable type: Sassmap; filter: size, public",
       "dependency": "WCSS: ./src/utilityMixins/_spacingUtility.scss",
-      "buildPath": "./dist/auro-classic/",
+      "buildPath": "./dist/legacy/auro-classic/",
       "files": [
         {
           "destination": "SCSSVariableMap.scss",
@@ -70,7 +70,7 @@
       "transformGroup": "css",
       "prefix": "ds",
       "comment": "File type: CSS; variable type: CSS; filter: public",
-      "buildPath": "./dist/auro-classic/",
+      "buildPath": "./dist/legacy/auro-classic/",
       "files": [
         {
           "destination": "CSSCustomProperties.css",
@@ -85,7 +85,7 @@
       "transformGroup": "css",
       "prefix": "ds",
       "comment": "File type: CSS; variable type: CSS; filter: size, public",
-      "buildPath": "./dist/auro-classic/",
+      "buildPath": "./dist/legacy/auro-classic/",
       "files": [
         {
           "destination": "CSSSizeCustomProperties.css",
@@ -103,7 +103,7 @@
       "transformGroup": "scss",
       "prefix": "ds",
       "comment": "File type: Sass; variable type: Sass; filter: size, public",
-      "buildPath": "./dist/auro-classic/",
+      "buildPath": "./dist/legacy/auro-classic/",
       "files": [
         {
           "destination": "SassSizeCustomProperties.scss",
@@ -121,7 +121,7 @@
       "transformGroup": "css",
       "prefix": "ds",
       "comment": "File type: SCSS; variable type: CSS; filter: public",
-      "buildPath": "./dist/auro-classic/",
+      "buildPath": "./dist/legacy/auro-classic/",
       "files": [
         {
           "destination": "SassCustomProperties.scss",
@@ -136,7 +136,7 @@
       "prefix": "ds",
       "transformGroup": "js",
       "comment": "File type: JS; data type: JS; filter: colors || public",
-      "buildPath": "./dist/auro-classic/",
+      "buildPath": "./dist/legacy/auro-classic/",
       "transforms": ["attribute/cti", "name/cti/kebab", "color/css"],
       "files": [
         {
@@ -155,7 +155,7 @@
       "prefix": "ds",
       "transformGroup": "js",
       "comment": "File type: JS; data type: JS; filter: colors || public",
-      "buildPath": "./dist/auro-classic/",
+      "buildPath": "./dist/legacy/auro-classic/",
       "files": [
         {
           "destination": "JSVariables--color.js",
@@ -173,7 +173,7 @@
       "transformGroup": "js",
       "prefix": "ds",
       "comment": "File type: JS; data type: JS; filter: classic colors",
-      "buildPath": "./dist/auro-classic/",
+      "buildPath": "./dist/legacy/auro-classic/",
       "transforms": ["attribute/cti", "name/cti/kebab", "color/css"],
       "files": [
         {
@@ -199,7 +199,7 @@
     "JSObject--deprecatedTokens": {
       "transformGroup": "js",
       "comment": "File type: JS; data type: JS; filter: deprecated",
-      "buildPath": "./dist/auro-classic/",
+      "buildPath": "./dist/legacy/auro-classic/",
       "transforms": ["attribute/cti", "name/cti/kebab", "color/css"],
       "files": [
         {

--- a/scripts/legacy/config-transparent.json
+++ b/scripts/legacy/config-transparent.json
@@ -6,7 +6,7 @@
       "transformGroup": "css",
       "prefix": "ds",
       "comment": "File type: CSS; variable type: CSS; filter: public",
-      "buildPath": "./dist/transparent/",
+      "buildPath": "./dist/legacy/transparent/",
       "files": [
         {
           "destination": "CSSCustomProperties--transparent.css",


### PR DESCRIPTION
# Alaska Airlines Pull Request

- Export `primitives/base` in `dist`
- Updates `dist` folder structure for better organization

Supports #319 

**Updated structure:**

![Screenshot 2025-06-04 at 3 02 58 PM](https://github.com/user-attachments/assets/9c36b275-091b-4bc0-afda-6d6f824c9a7c)

### Enhancements:
- Created a new `config-primitives-base.json`
- Renamed `config-template.json` to `config-themes.json` for theme configurations

### Documentation:
- Update themes documentation to reflect new bundled CSS file path under themes directory

## Testing

- Pull repo
- `npm run build`
- `dist` folder should be created with updated folder structure (screenshot above)
- Respective files have compiled without issue and tokens are reflected
- No errors during `build` process

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Generate and export base primitive tokens and restructure the distribution by introducing a themes subdirectory for bundled CSS, updating build scripts and configuration files to support these changes.

New Features:
- Export base primitive tokens in the distribution as `basePrimitives`
- Add `config-primitives-base.json` to build and include base tokens in dist
- Bundle theme CSS into a `themes` subfolder under dist

Enhancements:
- Rename `config-template.json` to `config-themes.json` for theme configurations
- Implement caching for base primitives builds to avoid redundant Style Dictionary executions
- Enhance CSS transform script to search both themes and root dist directories and create the themes folder if missing

Build:
- Update Style Dictionary script to integrate base primitives and renamed config
- Modify CSS transformation script to output bundled files into the new themes directory

Documentation:
- Update themes documentation to reference `themes/CSSCustomProperties--bundled.css`