### PR TITLE
fix: update auro-1 & auro-2 basic font-weight values to book

### DIFF
--- a/src/themes/auro-1/basic/type/weight.json
+++ b/src/themes/auro-1/basic/type/weight.json
@@ -18,7 +18,7 @@
           "deprecated": false,
           "public": true,
           "type": "semantic",
-          "value": "{type.weight.regular.value}"
+          "value": "{type.weight.book.value}"
         },
         "display": {
           "deprecated": false,

--- a/src/themes/auro-2/basic/type/weight.json
+++ b/src/themes/auro-2/basic/type/weight.json
@@ -18,7 +18,7 @@
           "deprecated": false,
           "public": true,
           "type": "semantic",
-          "value": "{type.weight.regular.value}"
+          "value": "{type.weight.book.value}"
         },
         "display": {
           "deprecated": false,


### PR DESCRIPTION
# Alaska Airlines Pull Request

Updates the `font-weight` values of the Basic type set of Auro-1 & Auro-2 themes to `450`.

## History

[In WCSS](https://github.com/AlaskaAirlines/WebCoreStyleSheets/issues/256), `AS-Circular-Regular.woff2` was incorrectly referenced as a `@font` style associated with `font-weight: 400`.

`AS-Circular-Regular.woff2` does not exist and is being replaced with `AS-Circular-Book.woff2`.

`font-weight: 450` is associated with Book, so these design tokens need to be updated accordingly.

https://dev.azure.com/itsals/E_Retain_Content/_workitems/edit/1342152

## Testing

Before:

```
--ds-basic-type-weight-body: 400;
```

After:

```
--ds-basic-type-weight-body: 450;
```

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Correct font-weight values in auro-1 and auro-2 basic type weight files from 400 to 450 to align with AS-Circular-Book.