### PR TITLE
ci: don't use custom output path in workflow #389

### DIFF
--- a/.github/workflows/sync-figma-to-tokens.yml
+++ b/.github/workflows/sync-figma-to-tokens.yml
@@ -25,7 +25,7 @@ jobs:
         run: npm install
 
       - name: Sync variables in Figma file to tokens
-        run: npm run sync-figma-to-tokens -- --output tokens
+        run: npm run sync-figma-to-tokens
         env:
           FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_TOKEN }}


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

CI:
- Remove the custom output directory argument from the Figma-to-tokens sync npm script in the GitHub Actions workflow.