### PR TITLE
fix: documentation dist paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ For most web applications, using CSS Custom Properties is recommended:
 
 ```js
 // In a React or similar application
-import "@aurodesignsystem/design-tokens/dist/alaska/CSSCustomProperties--alaska.css"
+import "@aurodesignsystem/design-tokens/dist/themes/alaska/CSSCustomProperties--alaska.css"
 ```
 
 ```html
 <!-- In an HTML file -->
-<link rel="stylesheet" href="node_modules/@aurodesignsystem/design-tokens/dist/alaska/CSSCustomProperties--alaska.css">
+<link rel="stylesheet" href="node_modules/@aurodesignsystem/design-tokens/dist/themes/alaska/CSSCustomProperties--alaska.css">
 ```
 
 ### With Sass
@@ -35,13 +35,13 @@ import "@aurodesignsystem/design-tokens/dist/alaska/CSSCustomProperties--alaska.
 When working with Sass:
 
 ```scss
-@import "~@aurodesignsystem/design-tokens/dist/alaska/primitives--alaska.scss";
+@import "~@aurodesignsystem/design-tokens/dist/themes/alaska/primitives--alaska.scss";
 ```
 
 ### JavaScript Usage
 
 ```js
-import { AuroColorAlertNotificationOnLight } from '@aurodesignsystem/design-tokens/dist/auro-classic/JSVariables--color.js';
+import { AuroColorAlertNotificationOnLight } from '@aurodesignsystem/design-tokens/dist/legacy/auro-classic/JSVariables--color.js';
 ```
 
 ## Available Themes

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -14,11 +14,11 @@ Each theme directory contains multiple file formats including CSS Custom Propert
 
 ```js
 // Import specific tokens
-import tokens from '@aurodesignsystem/design-tokens/dist/alaska/JSObject--allTokens.js';
+import tokens from '@aurodesignsystem/design-tokens/dist/themes/alaska/JSObject--allTokens.js';
 const { basic, advanced } = tokens;
 
 // Or import all tokens
-import * as AlaskaTokens from '@aurodesignsystem/design-tokens/dist/alaska/JSObject--allTokens.js';
+import * as AlaskaTokens from '@aurodesignsystem/design-tokens/dist/themes/alaska/JSObject--allTokens.js';
 ```
 
 ## File Format Reference

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -6,14 +6,14 @@ This guide provides instructions for migrating from Auro Design Tokens `v4`.
 
 The `v5` release introduced significant changes, including new themes, renamed tokens, and a restructured package.
 
-- **Restructured `./dist/` Directory**: All file import paths will need to be updated
+- **Restructured `./dist/themes` Directory**: All file import paths will need to be updated
 - **New Theme Names**: 
-  - The `v4.x` default theme is now called `Auro Classic` (located in `./dist/auro-classic`) and is deprecated
-  - **NEW** Alaska theme in `./dist/alaska`
-  - **NEW** Alaska Classic theme in `./dist/alaska-classic`
-  - **NEW** Hawaiian theme in `./dist/hawaiian`
-  - **NEW** Auro1 theme in `./dist/auro-1`
-  - **NEW** Auro2 theme in `./dist/auro-2`
+  - The `v4.x` default theme is now called `Auro Classic` (located in `./dist/legacy/auro-classic`) and is deprecated
+  - **NEW** Alaska theme in `./dist/themes/alaska`
+  - **NEW** Alaska Classic theme in `./dist/themes/alaska-classic`
+  - **NEW** Hawaiian theme in `./dist/themes/hawaiian`
+  - **NEW** Auro1 theme in `./dist/themes/auro-1`
+  - **NEW** Auro2 theme in `./dist/themes/auro-2`
 - **Unique Token Names**: Starting with `v5`, token names are distinct from those in `v4`, allowing both `v4` and later versions to coexist without conflict
 - **Theme Scoping**: Alaska and Hawaiian themes should not be used simultaneously within the same DOM scope
 - **Deprecated Tokens**: Some tokens have been completely removed beginning in `v5`.
@@ -23,5 +23,5 @@ The `v5` release introduced significant changes, including new themes, renamed t
 The `v4` filename conventions remain the same, but for Auro Classic (the deprecated theme that matches `v4`), file path imports will need to be updated to:
 
 ```scss
-@import "@aurodesignsystem/design-tokens/dist/auro-classic/*.*";
+@import "@aurodesignsystem/design-tokens/dist/legacy/auro-classic/*.*";
 ```


### PR DESCRIPTION
# Alaska Airlines Pull Request

The paths in the documentation did not reference the `/themes/` folder for modern themes, nor the `/legacy/` for Auro Classic.

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Update documentation to reflect the correct distribution paths for themes and legacy assets in the design-tokens package.

Bug Fixes:
- Correct incorrect import paths in documentation for Auro Classic legacy assets and modern theme distributions.

Documentation:
- Adjust migration, README, and API reference docs to use the updated dist/themes and dist/legacy paths for all theme import examples.