### PR TITLE
fix: app token name casing AB#1475780

### DIFF
--- a/dist/app/alaskaLight.json
+++ b/dist/app/alaskaLight.json
@@ -25,11 +25,11 @@
         "tertiarySubtle": "#c9e1a7"
       },
       "fare": {
-        "basiceconomy": "#97eaf8",
+        "basicEconomy": "#97eaf8",
         "business": "#01426a",
         "economy": "#0074ca",
         "first": "#00274a",
-        "premiumeconomy": "#005154"
+        "premiumEconomy": "#005154"
       },
       "pageBackground": {
         "standard": "#ffffff",
@@ -73,11 +73,11 @@
         "standard": "#2a2a2a"
       },
       "tierProgram": {
-        "loungetier": {
+        "loungeTier": {
           "lounge": "#01426a",
-          "loungeplus": "#53b390"
+          "loungePlus": "#53b390"
         },
-        "loyaltytier": {
+        "loyaltyTier": {
           "gold": "#fbdc7a",
           "goldMuted": "#fdefc4",
           "platinum": "#bcb8a4",
@@ -109,35 +109,35 @@
         "letterSpacing": 1.4,
         "lineHeight": "130%"
       },
-      "accentlg": {
+      "accentLg": {
         "fontFamily": "Good OT",
         "fontSize": 24,
         "fontWeight": "Cond News",
         "letterSpacing": 1.2,
         "lineHeight": "130%"
       },
-      "accentmd": {
+      "accentMd": {
         "fontFamily": "Good OT",
         "fontSize": 22,
         "fontWeight": "Cond Medium",
         "letterSpacing": 1.1,
         "lineHeight": "130%"
       },
-      "accentsm": {
+      "accentSm": {
         "fontFamily": "Good OT",
         "fontSize": 18,
         "fontWeight": "Cond Medium",
         "letterSpacing": 0.9,
         "lineHeight": "130%"
       },
-      "accentxl": {
+      "accentXl": {
         "fontFamily": "Good OT",
         "fontSize": 26,
         "fontWeight": "Cond News",
         "letterSpacing": 1.3,
         "lineHeight": "130%"
       },
-      "accentxs": {
+      "accentXs": {
         "fontFamily": "Good OT",
         "fontSize": 16,
         "fontWeight": "Cond Medium",
@@ -151,28 +151,28 @@
         "letterSpacing": 0,
         "lineHeight": 14
       },
-      "bodydefault": {
+      "bodyDefault": {
         "fontFamily": "AS Circular",
         "fontSize": 16,
         "fontWeight": "Book",
         "letterSpacing": 0,
         "lineHeight": 24
       },
-      "bodylg": {
+      "bodyLg": {
         "fontFamily": "AS Circular",
         "fontSize": 18,
         "fontWeight": "Book",
         "letterSpacing": 0,
         "lineHeight": 26
       },
-      "bodysm": {
+      "bodySm": {
         "fontFamily": "AS Circular",
         "fontSize": 14,
         "fontWeight": "Book",
         "letterSpacing": 0,
         "lineHeight": 20
       },
-      "bodyxs": {
+      "bodyXs": {
         "fontFamily": "AS Circular",
         "fontSize": 12,
         "fontWeight": "Book",
@@ -186,35 +186,35 @@
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displaylg": {
+      "displayLg": {
         "fontFamily": "AS Circular",
         "fontSize": 44,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displaymd": {
+      "displayMd": {
         "fontFamily": "AS Circular",
         "fontSize": 40,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displaysm": {
+      "displaySm": {
         "fontFamily": "AS Circular",
         "fontSize": 32,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displayxl": {
+      "displayXl": {
         "fontFamily": "AS Circular",
         "fontSize": 48,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displayxs": {
+      "displayXs": {
         "fontFamily": "AS Circular",
         "fontSize": 28,
         "fontWeight": "Light",
@@ -228,35 +228,35 @@
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headinglg": {
+      "headingLg": {
         "fontFamily": "AS Circular",
         "fontSize": 28,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingmd": {
+      "headingMd": {
         "fontFamily": "AS Circular",
         "fontSize": 26,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingsm": {
+      "headingSm": {
         "fontFamily": "AS Circular",
         "fontSize": 22,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingxl": {
+      "headingXl": {
         "fontFamily": "AS Circular",
         "fontSize": 32,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingxs": {
+      "headingXs": {
         "fontFamily": "AS Circular",
         "fontSize": 20,
         "fontWeight": "Book",

--- a/dist/app/atmosLight.json
+++ b/dist/app/atmosLight.json
@@ -25,11 +25,11 @@
         "tertiarySubtle": "#e9e6d9"
       },
       "fare": {
-        "basiceconomy": "#97eaf8",
+        "basicEconomy": "#97eaf8",
         "business": "#002c4e",
         "economy": "#0074ca",
         "first": "#101d2c",
-        "premiumeconomy": "#005154"
+        "premiumEconomy": "#005154"
       },
       "pageBackground": {
         "standard": "#ffffff",
@@ -73,11 +73,11 @@
         "standard": "#101d2c"
       },
       "tierProgram": {
-        "loungetier": {
+        "loungeTier": {
           "lounge": "#01426a",
-          "loungeplus": "#53b390"
+          "loungePlus": "#53b390"
         },
-        "loyaltytier": {
+        "loyaltyTier": {
           "gold": "#fbdc7a",
           "goldMuted": "#fdefc4",
           "platinum": "#bcb8a4",
@@ -109,35 +109,35 @@
         "letterSpacing": 1.4,
         "lineHeight": "130%"
       },
-      "accentlg": {
+      "accentLg": {
         "fontFamily": "AS Circular",
         "fontSize": 24,
         "fontWeight": "Medium",
         "letterSpacing": 1.2,
         "lineHeight": "130%"
       },
-      "accentmd": {
+      "accentMd": {
         "fontFamily": "AS Circular",
         "fontSize": 22,
         "fontWeight": "Medium",
         "letterSpacing": 1.1,
         "lineHeight": "130%"
       },
-      "accentsm": {
+      "accentSm": {
         "fontFamily": "AS Circular",
         "fontSize": 18,
         "fontWeight": "Medium",
         "letterSpacing": 0.9,
         "lineHeight": "130%"
       },
-      "accentxl": {
+      "accentXl": {
         "fontFamily": "AS Circular",
         "fontSize": 26,
         "fontWeight": "Medium",
         "letterSpacing": 1.3,
         "lineHeight": "130%"
       },
-      "accentxs": {
+      "accentXs": {
         "fontFamily": "AS Circular",
         "fontSize": 16,
         "fontWeight": "Medium",
@@ -151,28 +151,28 @@
         "letterSpacing": 0,
         "lineHeight": 14
       },
-      "bodydefault": {
+      "bodyDefault": {
         "fontFamily": "AS Circular",
         "fontSize": 16,
         "fontWeight": "Book",
         "letterSpacing": 0,
         "lineHeight": 24
       },
-      "bodylg": {
+      "bodyLg": {
         "fontFamily": "AS Circular",
         "fontSize": 18,
         "fontWeight": "Book",
         "letterSpacing": 0,
         "lineHeight": 26
       },
-      "bodysm": {
+      "bodySm": {
         "fontFamily": "AS Circular",
         "fontSize": 14,
         "fontWeight": "Book",
         "letterSpacing": 0,
         "lineHeight": 20
       },
-      "bodyxs": {
+      "bodyXs": {
         "fontFamily": "AS Circular",
         "fontSize": 12,
         "fontWeight": "Book",
@@ -186,35 +186,35 @@
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displaylg": {
+      "displayLg": {
         "fontFamily": "Teodor",
         "fontSize": 44,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displaymd": {
+      "displayMd": {
         "fontFamily": "Teodor",
         "fontSize": 40,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displaysm": {
+      "displaySm": {
         "fontFamily": "Teodor",
         "fontSize": 32,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displayxl": {
+      "displayXl": {
         "fontFamily": "Teodor",
         "fontSize": 48,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displayxs": {
+      "displayXs": {
         "fontFamily": "Teodor",
         "fontSize": 28,
         "fontWeight": "Light",
@@ -228,35 +228,35 @@
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headinglg": {
+      "headingLg": {
         "fontFamily": "AS Circular",
         "fontSize": 28,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingmd": {
+      "headingMd": {
         "fontFamily": "AS Circular",
         "fontSize": 26,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingsm": {
+      "headingSm": {
         "fontFamily": "AS Circular",
         "fontSize": 22,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingxl": {
+      "headingXl": {
         "fontFamily": "AS Circular",
         "fontSize": 32,
         "fontWeight": "Light",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingxs": {
+      "headingXs": {
         "fontFamily": "AS Circular",
         "fontSize": 20,
         "fontWeight": "Light",

--- a/dist/app/hawaiianLight.json
+++ b/dist/app/hawaiianLight.json
@@ -25,11 +25,11 @@
         "tertiarySubtle": "#ff9080"
       },
       "fare": {
-        "basiceconomy": "#d0d0d0",
+        "basicEconomy": "#d0d0d0",
         "business": "#463c8f",
         "economy": "#ce0c88",
         "first": "#463c8f",
-        "premiumeconomy": "#1b6976"
+        "premiumEconomy": "#1b6976"
       },
       "pageBackground": {
         "standard": "#ffffff",
@@ -73,11 +73,11 @@
         "standard": "#000000"
       },
       "tierProgram": {
-        "loungetier": {
+        "loungeTier": {
           "lounge": "#01426a",
-          "loungeplus": "#53b390"
+          "loungePlus": "#53b390"
         },
-        "loyaltytier": {
+        "loyaltyTier": {
           "gold": "#fbdc7a",
           "goldMuted": "#fdefc4",
           "platinum": "#bcb8a4",
@@ -109,35 +109,35 @@
         "letterSpacing": 1.4,
         "lineHeight": "130%"
       },
-      "accentlg": {
+      "accentLg": {
         "fontFamily": "Slate Pro",
         "fontSize": 24,
         "fontWeight": "Regular",
         "letterSpacing": 1.2,
         "lineHeight": "130%"
       },
-      "accentmd": {
+      "accentMd": {
         "fontFamily": "Slate Pro",
         "fontSize": 22,
         "fontWeight": "Medium",
         "letterSpacing": 1.1,
         "lineHeight": "130%"
       },
-      "accentsm": {
+      "accentSm": {
         "fontFamily": "Slate Pro",
         "fontSize": 18,
         "fontWeight": "Medium",
         "letterSpacing": 0.9,
         "lineHeight": "130%"
       },
-      "accentxl": {
+      "accentXl": {
         "fontFamily": "Slate Pro",
         "fontSize": 26,
         "fontWeight": "Regular",
         "letterSpacing": 1.3,
         "lineHeight": "130%"
       },
-      "accentxs": {
+      "accentXs": {
         "fontFamily": "Slate Pro",
         "fontSize": 16,
         "fontWeight": "Medium",
@@ -151,28 +151,28 @@
         "letterSpacing": 0,
         "lineHeight": 14
       },
-      "bodydefault": {
+      "bodyDefault": {
         "fontFamily": "Slate Pro",
         "fontSize": 16,
         "fontWeight": "Regular",
         "letterSpacing": 0,
         "lineHeight": 24
       },
-      "bodylg": {
+      "bodyLg": {
         "fontFamily": "Slate Pro",
         "fontSize": 18,
         "fontWeight": "Regular",
         "letterSpacing": 0,
         "lineHeight": 26
       },
-      "bodysm": {
+      "bodySm": {
         "fontFamily": "Slate Pro",
         "fontSize": 14,
         "fontWeight": "Regular",
         "letterSpacing": 0,
         "lineHeight": 20
       },
-      "bodyxs": {
+      "bodyXs": {
         "fontFamily": "Slate Pro",
         "fontSize": 12,
         "fontWeight": "Regular",
@@ -186,35 +186,35 @@
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displaylg": {
+      "displayLg": {
         "fontFamily": "Chronicle Display",
         "fontSize": 44,
         "fontWeight": "Semibold",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displaymd": {
+      "displayMd": {
         "fontFamily": "Chronicle Display",
         "fontSize": 40,
         "fontWeight": "Semibold",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displaysm": {
+      "displaySm": {
         "fontFamily": "Chronicle Display",
         "fontSize": 32,
         "fontWeight": "Semibold",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displayxl": {
+      "displayXl": {
         "fontFamily": "Chronicle Display",
         "fontSize": 48,
         "fontWeight": "Semibold",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displayxs": {
+      "displayXs": {
         "fontFamily": "Chronicle Display",
         "fontSize": 28,
         "fontWeight": "Semibold",
@@ -228,35 +228,35 @@
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headinglg": {
+      "headingLg": {
         "fontFamily": "Slate Pro",
         "fontSize": 28,
         "fontWeight": "Regular",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingmd": {
+      "headingMd": {
         "fontFamily": "Slate Pro",
         "fontSize": 26,
         "fontWeight": "Medium",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingsm": {
+      "headingSm": {
         "fontFamily": "Slate Pro",
         "fontSize": 22,
         "fontWeight": "Medium",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingxl": {
+      "headingXl": {
         "fontFamily": "Slate Pro",
         "fontSize": 32,
         "fontWeight": "Regular",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingxs": {
+      "headingXs": {
         "fontFamily": "Slate Pro",
         "fontSize": 20,
         "fontWeight": "Medium",

--- a/dist/app/test.json
+++ b/dist/app/test.json
@@ -25,11 +25,11 @@
         "tertiarySubtle": "#adadad"
       },
       "fare": {
-        "basiceconomy": "#d0d0d0",
+        "basicEconomy": "#d0d0d0",
         "business": "#3d3d3d",
         "economy": "#676767",
         "first": "#2a2a2a",
-        "premiumeconomy": "#525252"
+        "premiumEconomy": "#525252"
       },
       "pageBackground": {
         "standard": "#ffffff",
@@ -73,11 +73,11 @@
         "standard": "#000000"
       },
       "tierProgram": {
-        "loungetier": {
+        "loungeTier": {
           "lounge": "#3d3d3d",
-          "loungeplus": "#7e7e7e"
+          "loungePlus": "#7e7e7e"
         },
-        "loyaltytier": {
+        "loyaltyTier": {
           "gold": "#c5c5c5",
           "goldMuted": "#dddddd",
           "platinum": "#adadad",
@@ -109,35 +109,35 @@
         "letterSpacing": 1.4,
         "lineHeight": "130%"
       },
-      "accentlg": {
+      "accentLg": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 24,
         "fontWeight": "MediumItalic",
         "letterSpacing": 1.2,
         "lineHeight": "130%"
       },
-      "accentmd": {
+      "accentMd": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 22,
         "fontWeight": "MediumItalic",
         "letterSpacing": 1.1,
         "lineHeight": "130%"
       },
-      "accentsm": {
+      "accentSm": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 18,
         "fontWeight": "MediumItalic",
         "letterSpacing": 0.9,
         "lineHeight": "130%"
       },
-      "accentxl": {
+      "accentXl": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 26,
         "fontWeight": "MediumItalic",
         "letterSpacing": 1.3,
         "lineHeight": "130%"
       },
-      "accentxs": {
+      "accentXs": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 16,
         "fontWeight": "MediumItalic",
@@ -151,28 +151,28 @@
         "letterSpacing": 0,
         "lineHeight": 14
       },
-      "bodydefault": {
+      "bodyDefault": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 16,
         "fontWeight": "MediumItalic",
         "letterSpacing": 0,
         "lineHeight": 24
       },
-      "bodylg": {
+      "bodyLg": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 18,
         "fontWeight": "MediumItalic",
         "letterSpacing": 0,
         "lineHeight": 26
       },
-      "bodysm": {
+      "bodySm": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 14,
         "fontWeight": "MediumItalic",
         "letterSpacing": 0,
         "lineHeight": 20
       },
-      "bodyxs": {
+      "bodyXs": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 12,
         "fontWeight": "MediumItalic",
@@ -186,35 +186,35 @@
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displaylg": {
+      "displayLg": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 44,
         "fontWeight": "MediumItalic",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displaymd": {
+      "displayMd": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 40,
         "fontWeight": "MediumItalic",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displaysm": {
+      "displaySm": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 32,
         "fontWeight": "MediumItalic",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displayxl": {
+      "displayXl": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 48,
         "fontWeight": "MediumItalic",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "displayxs": {
+      "displayXs": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 28,
         "fontWeight": "MediumItalic",
@@ -228,35 +228,35 @@
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headinglg": {
+      "headingLg": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 28,
         "fontWeight": "MediumItalic",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingmd": {
+      "headingMd": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 26,
         "fontWeight": "MediumItalic",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingsm": {
+      "headingSm": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 22,
         "fontWeight": "MediumItalic",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingxl": {
+      "headingXl": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 32,
         "fontWeight": "MediumItalic",
         "letterSpacing": 0,
         "lineHeight": "130%"
       },
-      "headingxs": {
+      "headingXs": {
         "fontFamily": "OpenSans-MediumItalic",
         "fontSize": 20,
         "fontWeight": "MediumItalic",

--- a/scripts/figmaExportUtil.mjs
+++ b/scripts/figmaExportUtil.mjs
@@ -478,7 +478,31 @@ export default class ExportUtil {
         'lineheight': 'lineHeight',
         'displayname': 'displayName',
         'iconurl': 'iconUrl',
-        'webviewcode': 'webviewCode'
+        'webviewcode': 'webviewCode',
+        'basiceconomy': 'basicEconomy',
+        'premiumeconomy': 'premiumEconomy',
+        'loungetier': 'loungeTier',
+        'loungeplus': 'loungePlus',
+        'loyaltytier': 'loyaltyTier',
+        'accentlg': 'accentLg',
+        'accentmd': 'accentMd',
+        'accentsm': 'accentSm',
+        'accentxl': 'accentXl',
+        'accentxs': 'accentXs',
+        'bodydefault': 'bodyDefault',
+        'bodylg': 'bodyLg',
+        'bodysm': 'bodySm',
+        'bodyxs': 'bodyXs',
+        'displaylg': 'displayLg',
+        'displaymd': 'displayMd',
+        'displaysm': 'displaySm',
+        'displayxs': 'displayXs',
+        'displayxl': 'displayXl',
+        'headinglg': 'headingLg',
+        'headingmd': 'headingMd',
+        'headingsm': 'headingSm',
+        'headingxl': 'headingXl',
+        'headingxs': 'headingXs'
       };
 
       this.processedJson = this.renameKeys(this.processedJson, keyMappings);


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Normalize app design token key casing for exported Figma tokens and regenerate app token JSON outputs.

Bug Fixes:
- Correct mismatched casing between source design tokens and expected app token key names for various fare, lounge, and typography tokens in the Figma export utility.

Enhancements:
- Extend the Figma export key-mapping to cover additional fare, lounge, and typography token names used by app themes.