### PR TITLE
ci: update Node.js versions and enhance permissions in CI workflow for Trusted Publishing AB#1597899

### DIFF
--- a/.github/workflows/testPublish.yml
+++ b/.github/workflows/testPublish.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22, 24]
 
     steps:
       - uses: actions/checkout@v4
@@ -33,16 +33,24 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: write # to push the version commit and publish the GitHub release
+      issues: write # to comment on released issues
+      pull-requests: write # to comment on released pull requests
+      id-token: write # required for npm Trusted Publishing (OIDC) + provenance
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g npm@12 # Trusted Publishing requires npm >= 11.5.1
       - run: npm ci
       - run: npm run build
-      - uses: cycjimmy/semantic-release-action@v4
+      - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # Fallback only

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     ]
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "keywords": [
     "alaska airlines",


### PR DESCRIPTION
# Alaska Airlines Pull Request

Moves release publishing for `@aurodesignsystem/design-tokens` from token-based npm auth to npm Trusted Publishers (OIDC). The workflow file stays `testPublish.yml` so the npmjs.com binding keeps pointing at it. The release job now runs `npx semantic-release` instead of the `cycjimmy/semantic-release-action`, adds the OIDC permissions block (`id-token: write`) and provenance through `publishConfig`, installs npm@12, runs on Node 22 with `registry-url` set, and keeps `NPM_TOKEN` as a fallback for now. The test matrix drops Node 20 and now runs on 22 and 24.

## Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Migrate the package release workflow to use npm Trusted Publishing with updated Node.js versions and provenance-enabled publishing.

New Features:
- Enable npm provenance for published packages via publishConfig settings.

Enhancements:
- Update CI test matrix and release job to run on newer Node.js versions (22 and 24) and use npx semantic-release instead of the semantic-release GitHub Action.
- Configure CI release job permissions and Node.js/npm setup to support npm Trusted Publishing while retaining NPM token as a fallback.